### PR TITLE
change column name

### DIFF
--- a/src/Console/Commands/DataImport/Hub/Resources/DbHubUserCompanyRealEstateDevelopment.php
+++ b/src/Console/Commands/DataImport/Hub/Resources/DbHubUserCompanyRealEstateDevelopment.php
@@ -27,6 +27,7 @@ class DbHubUserCompanyRealEstateDevelopment
         $query = "SELECT user_company.uuid as user_company_uuid, ucred.*
             FROM user_company_real_estate_developments ucred
             INNER JOIN user_companies user_company on user_company.id = ucred.linkable_id
+            WHERE ucred.linkable_type = 'App\\Models\\UserCompany'
             ORDER BY user_company_uuid
             LIMIT :limit
             OFFSET :offset";

--- a/src/Console/Commands/DataImport/Hub/Resources/DbHubUserCompanyRealEstateDevelopment.php
+++ b/src/Console/Commands/DataImport/Hub/Resources/DbHubUserCompanyRealEstateDevelopment.php
@@ -26,7 +26,7 @@ class DbHubUserCompanyRealEstateDevelopment
     {
         $query = "SELECT user_company.uuid as user_company_uuid, ucred.*
             FROM user_company_real_estate_developments ucred
-            INNER JOIN user_companies user_company on user_company.id = ucred.user_company_id
+            INNER JOIN user_companies user_company on user_company.id = ucred.linkable_id
             ORDER BY user_company_uuid
             LIMIT :limit
             OFFSET :offset";


### PR DESCRIPTION
# Problema
Ao rodar o comando `php artisan dataimport:hub` era feito uma query aonde a coluna não existia na tabela `user_company_real_estate_developments`, gerando o seguinte erro.
```
SQLSTATE[42S22]: Column not found: 1054 Unknown column 'ucred.user_company_id' in 'on clause' (SQL: SELECT user_company.uuid as user_company_uuid, ucred.* FROM user_company_real_estate_developments ucred INNER JOIN user_companies user_company on user_company.id = ucred.user_company_id ORDER BY user_company_uuid LIMIT :limit OFFSET :offset)
```

# Solução
Trocar a coluna `user_company_id` para `linkable_id`.