### PR TITLE
Adicionando o campo `is_post_construction` na mensageria e Data Import

### DIFF
--- a/src/Console/Commands/DataImport/Hub/Resources/UserCompanyImport.php
+++ b/src/Console/Commands/DataImport/Hub/Resources/UserCompanyImport.php
@@ -24,6 +24,7 @@ class UserCompanyImport
         $userCompanyModel->company_id = $this->getCompanyId($userCompany->hub_company_uuid);
         $userCompanyModel->position_id = $this->getPositionId($userCompany->hub_position_uuid);
         $userCompanyModel->is_seller = $userCompany->is_seller;
+        $userCompanyModel->is_post_construction = $userCompany->is_post_construction;
         $userCompanyModel->has_all_real_estate_developments = $userCompany->has_all_real_estate_developments;
         $userCompanyModel->has_specific_permissions = $userCompany->has_specific_permissions;
         $userCompanyModel->created_at = $userCompany->created_at;

--- a/src/Console/Commands/Messages/Resources/Helpers/CompanyLinksHelper.php
+++ b/src/Console/Commands/Messages/Resources/Helpers/CompanyLinksHelper.php
@@ -23,6 +23,7 @@ trait CompanyLinksHelper
         $userCompanyModel->company_id = $this->getCompanyId($message->company_uuid);
         $userCompanyModel->position_id = $this->getPositionId($message->position_uuid);
         $userCompanyModel->is_seller = $message->is_seller;
+        $userCompanyModel->is_post_construction = $message->is_post_construction;
         $userCompanyModel->has_all_real_estate_developments = $message->has_all_real_estate_developments;
         $userCompanyModel->has_specific_permissions = $message->has_specific_permissions;
         $userCompanyModel->created_at = $message->created_at;


### PR DESCRIPTION
Esta solicitação de pull introduz uma nova propriedade, `is_post_construction`, ao modelo `UserCompany` e garante que ela seja tratada corretamente nos fluxos de trabalho de importação de dados e de processamento de mensagens.

### Alterações relacionadas à propriedade `is_post_construction`:

* [`src/Console/Commands/DataImport/Hub/Resources/UserCompanyImport.php`](diffhunk://#diff-a56528df65f3e2c49449bbfa38da6b0954153ad34c2ffd70a14eb4e54b6210a8R27): Suporte adicionado para a propriedade `is_post_construction` no método `import` para lidar corretamente com importações de dados.
* [`src/Console/Commands/Messages/Resources/Helpers/CompanyLinksHelper.php`](diffhunk://#diff-02518bc75c9284ea24870151ea9eea02d5671984a178316ebdee6e2068af7812R26): O método `userCompaniesCreateOrUpdate` foi atualizado para incluir a propriedade `is_post_construction`, garantindo que ela seja processada durante o tratamento de mensagens.