### PR TITLE
Aprimorando o BrandImport e o BrandsHelper para o gerenciamento de UUIDs e a criação de marcas.

### DIFF
--- a/database/migrations/add_main_company_id_on_brands_table.php.stub
+++ b/database/migrations/add_main_company_id_on_brands_table.php.stub
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        if (Schema::hasTable('hub_brands')) {
+            if (! Schema::hasColumn('hub_brands', 'main_company_id')){
+                Schema::table('hub_brands', function (Blueprint $table) {
+                    $table->after('name', function ($table) {
+                        $table->foreignId('main_company_id')
+                            ->nullable()
+                            ->constrained('hub_companies')
+                            ->nullOnDelete()
+                            ->cascadeOnUpdate();
+                    });
+                });
+            }
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        if (Schema::hasTable('hub_brands')) {
+            Schema::table('hub_brands', function (Blueprint $table) {
+                $table->dropForeign(['main_company_id']);
+                $table->dropColumn('main_company_id');
+            });
+        }
+    }
+};

--- a/src/Console/Commands/DataImport/Hub/Resources/BrandImport.php
+++ b/src/Console/Commands/DataImport/Hub/Resources/BrandImport.php
@@ -8,19 +8,35 @@ class BrandImport
     {
         $brandModelFromConfig = app(config('hub.model_brand'));
 
-        $permissionModel = $brandModelFromConfig::where('uuid', $brand->uuid)
+        $brandModel = $brandModelFromConfig::where('uuid', $brand->uuid)
             ->first();
 
-        if (! $permissionModel) {
-            $permissionModel = new $brandModelFromConfig;
+        if (! $brandModel) {
+            $brandModel = new $brandModelFromConfig;
         }
 
-        $permissionModel->uuid = $brand->uuid;
-        $permissionModel->name = $brand->name;
-        $permissionModel->created_at = $brand->created_at;
-        $permissionModel->updated_at = $brand->updated_at;
-        $permissionModel->deleted_at = $brand->deleted_at;
+        $brandModel->uuid = $brand->uuid;
+        $brandModel->name = $brand->name;
+        $brandModel->main_company_id = $this->getCompanyId($brand->main_company_uuid);
+        $brandModel->created_at = $brand->created_at;
+        $brandModel->updated_at = $brand->updated_at;
+        $brandModel->deleted_at = $brand->deleted_at;
 
-        $permissionModel->save();
+        $brandModel->save();
+    }
+
+    private function getCompanyId(?string $hubCompanyUuid): ?int
+    {
+        if ($hubCompanyUuid) {
+            $companyClass = config('hub.model_company');
+            $hubCompany = $companyClass::withTrashed()
+                ->where('uuid', $hubCompanyUuid)
+                ->first();
+            if ($hubCompany) {
+                return $hubCompany->id;
+            }
+        }
+
+        return null;
     }
 }

--- a/src/Console/Commands/DataImport/Hub/Resources/DbHubBrand.php
+++ b/src/Console/Commands/DataImport/Hub/Resources/DbHubBrand.php
@@ -16,7 +16,7 @@ class DbHubBrand
 
     public function getBrands(int $limit, int $offset): array
     {
-        $query = 'SELECT b.* FROM brands b LIMIT :limit OFFSET :offset';
+        $query = 'SELECT b.*, c.uuid as main_company_uuid FROM brands b LEFT JOIN companies c ON b.main_company_id = c.id LIMIT :limit OFFSET :offset';
 
         return DB::connection('sp_hub')->select($query, [
             'limit' => $limit,

--- a/src/Console/Commands/Messages/Resources/Helpers/BrandsHelper.php
+++ b/src/Console/Commands/Messages/Resources/Helpers/BrandsHelper.php
@@ -3,6 +3,7 @@
 namespace BildVitta\SpHub\Console\Commands\Messages\Resources\Helpers;
 
 use BildVitta\Hub\Entities\HubBrand;
+use BildVitta\SpHub\Models\HubCompany;
 
 trait BrandsHelper
 {
@@ -14,6 +15,16 @@ trait BrandsHelper
         }
 
         $brand->name = $message->name;
+
+        if (property_exists($message, 'main_company_uuid')) {
+            $brand->main_company_id = null;
+            if ($message->main_company_uuid) {
+                $brand->main_company_id = HubCompany::withTrashed()->where('uuid', $message->main_company_uuid)->value('id');
+            }
+        } else {
+            $brand->main_company_id = $message->main_company_id ?? null;
+        }
+
         $brand->created_at = $message->created_at;
         $brand->updated_at = $message->updated_at;
         $brand->deleted_at = $message->deleted_at;

--- a/src/SpHubServiceProvider.php
+++ b/src/SpHubServiceProvider.php
@@ -32,6 +32,7 @@ class SpHubServiceProvider extends PackageServiceProvider
                 'add_public_list_on_hub_companies_table',
                 'add_external_code_column_to_hub_companies_table',
                 'add_is_approving_proposals_and_approval_level_to_user_companies_table',
+                'add_main_company_id_on_brands_table.php',
             ])
             ->runsMigrations();
     }

--- a/src/SpHubServiceProvider.php
+++ b/src/SpHubServiceProvider.php
@@ -32,7 +32,7 @@ class SpHubServiceProvider extends PackageServiceProvider
                 'add_public_list_on_hub_companies_table',
                 'add_external_code_column_to_hub_companies_table',
                 'add_is_approving_proposals_and_approval_level_to_user_companies_table',
-                'add_main_company_id_on_brands_table.php',
+                'add_main_company_id_on_brands_table',
             ])
             ->runsMigrations();
     }


### PR DESCRIPTION
Esta solicitação de pull atualiza a forma como os relacionamentos entre marcas e empresas são tratados durante a importação e o envio de mensagens de dados, garantindo que o `main_company_id` seja definido corretamente usando o UUID da empresa quando disponível. As alterações melhoram a consistência dos dados, resolvendo sempre a referência da empresa por meio de seu UUID e atualizando o processo de importação e a lógica auxiliar de acordo.

**Tratamento de Relacionamentos entre Marcas e Empresas:**

* Em `BrandImport.php`, a lógica de importação foi atualizada para definir o `main_company_id` consultando o ID da empresa usando o `main_company_uuid` fornecido, garantindo a associação correta mesmo para empresas excluídas logicamente. Foi adicionado um método auxiliar privado `getCompanyId` para encapsular essa consulta.

* Em `DbHubBrand.php`, a consulta SQL em `getBrands` foi modificada para incluir o `main_company_uuid` por meio de uma junção com a tabela `companies`, de forma que o processo de importação tenha acesso ao UUID para o mapeamento correto.

**Mensagens e Lógica Auxiliar:**

* Em `BrandsHelper.php`, o modelo `HubCompany` foi importado para permitir a busca de empresas por UUID.

* O método `brandCreateOrUpdate` em `BrandsHelper.php` foi atualizado para priorizar a definição de `main_company_id` usando `main_company_uuid` se presente, recorrendo à atribuição direta de ID caso contrário. Isso garante a consistência com a lógica de importação e oferece suporte a formatos de mensagem legados e novos.